### PR TITLE
SWPROT-8953: build: Allow packaging in project clients once

### DIFF
--- a/cmake/include/package.cmake
+++ b/cmake/include/package.cmake
@@ -1,13 +1,16 @@
 message(STATUS "Components of Unify which will have deb packages"
                ": ${CPACK_COMPONENTS_ALL}")
 
-include(CPack)
+if(PROJECT_IS_TOP_LEVEL)
+  message(STATUS "cpack: Included from ${CMAKE_SOURCE_DIR}")
+  include(CPack)
 
-foreach(PKG_NAME IN LISTS CPACK_COMPONENTS_ALL)
-      string(TOUPPER ${PKG_NAME} PKG_NAME_UPPER)
-  cpack_add_component(
-    PKG_NAME
-    DISPLAY_NAME ${PKG_NAME}
-    DESCRIPTION ${CPACK_DEBIAN_${PKG_NAME_UPPER}_DESCRIPTION}
-    INSTALL_TYPES Full)
-endforeach()
+  foreach(PKG_NAME IN LISTS CPACK_COMPONENTS_ALL)
+    string(TOUPPER ${PKG_NAME} PKG_NAME_UPPER)
+    cpack_add_component(
+      PKG_NAME
+      DISPLAY_NAME ${PKG_NAME}
+      DESCRIPTION ${CPACK_DEBIAN_${PKG_NAME_UPPER}_DESCRIPTION}
+      INSTALL_TYPES Full)
+  endforeach()
+endif()


### PR DESCRIPTION
The client project should include cpack once,
the change prevents double inclusion

This help to use core as dependency for unify-z-wave

It was made for v7 but can also apply to v6

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


