### PR TITLE
SWPROT-8953: Add NEWS.md to track migration from UnifySDK to zpc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,29 @@
+# News
+
+All notable changes to this project will be documented in this file.
+
+**Full Changelog**:
+https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/commits
+
+## ver_1.6.0-RC4
+
+This tag was added once CI was able to produce unsupported binaries:
+
+https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/releases/tag/ver_1.6.0-RC4
+
+Please prefer UnifySDK assets, linked in previous chapter.
+
+
+## ver_1.6.0-RC0
+
+The initial import of this project, is coming from latest release of
+UnifySDK:
+
+https://github.com/SiliconLabs/UnifySDK/releases/tag/ver_1.6.0
+
+This tag is marked as RC0 because it won't be supported in this
+downstream repostiory.
+
+Sources should be mostly same as above:
+
+https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/releases/tag/ver_1.6.0-RC0


### PR DESCRIPTION
## Change


    SWPROT-8953: Add NEWS.md to track migration from UnifySDK to zpc
    
    This change will be updated on each integration batch,
    commit messages will be helpful to manage cross context information.
    
    For the record all changes since tag ver_1.6.0-RC4
    were initially done at z-wave-protocol-controller project.

<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


