### PR TITLE
SWPROT-8953: build: Update cargo to match unify v7 ci

### DIFF
--- a/helper.mk
+++ b/helper.mk
@@ -37,7 +37,7 @@ packages+=python3-jinja2
 packages+=yarnpkg
 
 rust_url?=https://sh.rustup.rs
-RUST_VERSION?=1.65.0
+RUST_VERSION?=1.71.0
 export PATH := ${HOME}/.cargo/bin:${PATH}
 
 
@@ -60,6 +60,11 @@ cmake_options+=-DCMAKE_SYSTEM_PROCESSOR="${CMAKE_SYSTEM_PROCESSOR}"
 export CMAKE_SYSTEM_PROCESSOR
 else
 # CMAKE_SYSTEM_PROCESSOR?=$(shell uname -m)
+endif
+
+ifdef CARGO_TARGET_TRIPLE
+cmake_options+=-DCARGO_TARGET_TRIPLE="${CARGO_TARGET_TRIPLE}"
+export CMAKE_TARGET_TRIPLE
 endif
 
 
@@ -88,11 +93,14 @@ setup/rust:
 	-which rustc
 	rustc --version
 	cargo --version
+	rustc --print target-list
+	@echo "$@: TODO: https://github.com/kornelski/cargo-deb/issues/159"
+	cargo install --version 1.44.0 --locked cargo-deb
 	@echo "$@: TODO: Support stable version from https://releases.rs/ or older"
 
 setup/python:
 	python3 --version
-	@echo "$@: TODO: https://github.com/wbond/pybars3/issues/82"
+	@echo "$@: TODO: https://bugs.debian.org/1094297"
 	pip3 --version || echo "warning: Please install pip"
 	pip3 install "pybars3" \
 		|| pip3 install --break-system-packages "pybars3"


### PR DESCRIPTION
This was useful for building image-provider outside unify.

Unsure which version was the reference in UnifySDK-1.6, there was no reason to update if it worked for zpc.

On this topic it would be developer friendly that the version of debian stable currently rustc=1.63 https://tracker.debian.org/pkg/rustc

and also latest stable https://releases.rs/
currently Stable: 1.84.1
which might land in next debian-13

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


