### PR TITLE
SWPROT-8953: ci: github: Disable armhf as not building in qemu

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -14,7 +14,7 @@ jobs:
         arch:
           - amd64
           - arm64
-          - armhf
+          # - armhf # TODO Enable when supported
     steps:
       - uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
For some reason armhf is not buidling despite the tricks in helper script:

    [5/1594] Running: cargo build target unify_build
    error: failed to determine package fingerprint for build script for
    unify_attribute_poll v0.1.0
    (/.../unifysdk-src/components/unify_attribute_poll)
    (...)
    "Value too large for defined data type; class=Os (2)"

Amazingly no problems observed on arm64 (with same rustup versions)

Not only on github because ot is reproducable locally.

Not sure problem is related to symlinks,
issues to track at qemu, glibc, linux ext4...

Relate-to: https://gitlab.com/qemu-project/qemu/-/issues/263
Relate-to: https://bugzilla.kernel.org/show_bug.cgi?id=205957
Relate-to: https://sourceware.org/bugzilla/show_bug.cgi?id=23960
Relate-to: https://sourceware.org/bugzilla/show_bug.cgi?id=23960
Relate-to: https://bugs.launchpad.net/qemu/+bug/1805913
Relate-to: https://github.com/rust-lang/cargo/issues/8719
Relate-to: https://github.com/rust-lang/cargo/issues/9881
Relate-to: https://github.com/rust-lang/cargo/issues/9545#issuecomment-855282576
Origin: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/14

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


