### PR TITLE
SWPROT-8953: Disable Werror on UnifySDK dep release

### DIFF
--- a/cmake/modules/FindUnifySDK.cmake
+++ b/cmake/modules/FindUnifySDK.cmake
@@ -27,12 +27,25 @@ if("${UNIFYSDK_GIT_TAG}" STREQUAL "")
   set(UNIFYSDK_GIT_TAG "main") # Override CMake default ("master")
 endif()
 
+if(${GIT_EXECUTABLE})
+else()
+  set(GIT_EXECUTABLE git)
+endif()
+
 FetchContent_Declare(
   UnifySDK
   GIT_REPOSITORY ${UNIFYSDK_GIT_REPOSITORY}
   GIT_TAG        ${UNIFYSDK_GIT_TAG}
   GIT_SUBMODULES_RECURSE True
   GIT_SHALLOW 1
+
+  # Prevent "fatal: unable to auto-detect email address"
+  GIT_CONFIG user.email=nobody@UnifySDK.localhost
+
+  PATCH_COMMAND ${GIT_EXECUTABLE}
+      -C <SOURCE_DIR>
+      am
+      ${PROJECT_SOURCE_DIR}/patches/UnifySDK/0001-UIC-3202-Relax-compiler-warnings-to-support-more-com.patch
 )
 
 message(STATUS "${CMAKE_PROJECT_NAME}: Depends: ${UNIFYSDK_GIT_REPOSITORY}#${UNIFYSDK_GIT_TAG}")

--- a/patches/UnifySDK/0001-UIC-3202-Relax-compiler-warnings-to-support-more-com.patch
+++ b/patches/UnifySDK/0001-UIC-3202-Relax-compiler-warnings-to-support-more-com.patch
@@ -1,0 +1,44 @@
+From 9e212f8578e945598096b90e18b91a662d5f98e6 Mon Sep 17 00:00:00 2001
+From: Philippe Coval <philippe.coval@silabs.com>
+Date: Tue, 23 Jan 2024 16:27:50 +0100
+Subject: [PATCH] UIC-3202: Relax compiler warnings to support more compilers
+
+Threating warning as error is a good practice durring development phase,
+for release it's ok to relax this to support more (future) compilers
+and then provide best effort support on non supported environements.
+
+For instance we might allow users to support stable version of gcc
+(gcc-13 currently which is not yet enabled in our CI)
+
+Of course this change should be reverted on development branch, ASAP,
+and introduced again for next releases.
+
+Ideally it should be near to release tags.
+
+Origin: uic/pull-requests/2704/overview
+Relate-to: uic/pull-requests/2705/overview?commentId=796680
+Relate-to: /x/FND4Dg#BrainstormItems-Identifystandardsbreakage
+Forwarded: uic/pull-requests/2704/overview
+Signed-off-by: Philippe Coval <philippe.coval@silabs.com>
+---
+ cmake/include/compiler_options.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/include/compiler_options.cmake b/cmake/include/compiler_options.cmake
+index 751ffe84bd..1f83caa008 100644
+--- a/cmake/include/compiler_options.cmake
++++ b/cmake/include/compiler_options.cmake
+@@ -31,8 +31,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON) # Do not allow fallback to previous C++
+ set(CMAKE_CXX_EXTENSIONS ON) # Enable gnu++11 extentions
+ 
+ # Set compiler Flags
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Werror -Wall")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -Werror -Wall")
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Wall")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -Wall")
+ 
+ # Only add code coverage when CMAKE_GCOV is True
+ if(CMAKE_GCOV)
+-- 
+2.39.5
+


### PR DESCRIPTION
As explain in patch it is good to use Werror in devel or ci branch not in releases (tags).

This change is not yet applied upstream,
to support more compilers, issue has been reported on OSX using

```
➜  ~ cc --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: x86_64-apple-darwin23.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
➜  ~ c++ --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: x86_64-apple-darwin23.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

I would be nice to fix this in the upstream too:

    .../unifysdk-src/components/uic_main/src/uic_init.c:77:21: \
    error: passing arguments to 'sl_log_read_config' \
    without a prototype is deprecated in all versions of C \
    and is not supported in C2x \
    [-Werror,-Wdeprecated-non-prototype]
    sl_log_read_config(NULL);

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


