### PR TITLE
SWPROT-8953: zpc: Relax Werror for release, to be reverted

### DIFF
--- a/cmake/include/compiler_options.cmake
+++ b/cmake/include/compiler_options.cmake
@@ -31,8 +31,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON) # Do not allow fallback to previous C++
 set(CMAKE_CXX_EXTENSIONS ON) # Enable gnu++11 extentions
 
 # Set compiler Flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Werror -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -Werror -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -Wall")
 
 # Only add code coverage when CMAKE_GCOV is True
 if(CMAKE_GCOV)


### PR DESCRIPTION
For developer experience it is a good practice to
attempt to support a different configuration (eg: MacOS, Yocto), This change will have to be reverted in the next developement cycle.

Origin: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pulls?q=author%3Arzr

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/25

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


