### PR TITLE
SWPROT-8953: libs2: Relax Werror for release, to be reverted

### DIFF
--- a/applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/CMakeLists.txt
+++ b/applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/CMakeLists.txt
@@ -8,7 +8,7 @@ if("${PROJECT_NAME}" STREQUAL "")
   add_definitions(-Dx86)
 
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
     # For gov/cobertura: do not use .c.o on the object files, only .o
     set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")


### PR DESCRIPTION
For developer experience it is a good practice to
attempt to support a different configuration (eg: MacOs, Yocto), This change will have to be reverted in the next developement cycle.

Origin: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/28

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


