### PR TITLE
SWPROT-8953: build: Enable image provider

### DIFF
--- a/helper.mk
+++ b/helper.mk
@@ -19,6 +19,7 @@ version?=$(shell git describe --tags || echo "0")
 # Allow overloading from env if needed
 # VERBOSE?=1
 BUILD_DEV_GUI?=OFF
+BUILD_IMAGE_PROVIDER?=ON
 
 cmake_options?=-B ${build_dir}
 
@@ -70,6 +71,10 @@ cmake_options+=-DBUILD_DEV_GUI=${BUILD_DEV_GUI}
 ifeq (${BUILD_DEV_GUI}, ON)
 packages+=nodejs
 endif
+endif
+
+ifdef BUILD_IMAGE_PROVIDER
+cmake_options+=-DBUILD_IMAGE_PROVIDER=${BUILD_IMAGE_PROVIDER}
 endif
 
 # Allow to bypass env detection, to support more build systems


### PR DESCRIPTION
Note this commit could be improved if applied to other base,

Observed issue (not present on current base with removed dirs):

failed to create symbolic link '/usr/local/opt/unifysdk/components/uic_rust' because existing path cannot be removed: Is a directory
failed to create symbolic link '/usr/local/opt/unifysdk/components/unify_attribute_poll' because existing path cannot be removed: Is a directory

It did not break while it should.

Also it has been observed that it fails to build on GH.

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/19

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


