### PR TITLE
SWPROT-8953: Reintroduce cmake/release-version.cmake with 1.7

### DIFF
--- a/cmake/release-version.cmake
+++ b/cmake/release-version.cmake
@@ -1,0 +1,1 @@
+SET(GIT_VERSION "ver_1.7.0")


### PR DESCRIPTION
This change is temporary to enable proper packaging filenames.

Should the git ref added before tagging? This is an odd practice.

This file will be deleted once,
versions when will be handled correctly
to avoid overlap between U and ZPC.

Revert "SWPROT-8953: Delete generated version file"

This reverts commit 198fdb0ac40146aa3209b3ec525cafb67b70b827.

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


