### PR TITLE
SWPROT-8953: git: Remove .gitattributes to be part of next release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-"bridge_binaries.zip" filter=lfs diff=lfs merge=lfs -text
-"zap-2022.1.10.dmg" filter=lfs diff=lfs merge=lfs -text
-"slc_cli_mac.zip" filter=lfs diff=lfs merge=lfs -text
-"zap_apack_mac.zip" filter=lfs diff=lfs merge=lfs -text
-"slc_cli_linux.zip" filter=lfs diff=lfs merge=lfs -text
-"zap_apack_linux.zip" filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This is something that should have been removed in latest release. It would be nice to release a revision version,
this will help also derivates projects to importing ver_1.7.1 ?

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


