### PR TITLE
SWPROT-8953: cmake: Drop vers_1.7.0 hardcoded version

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -16,9 +16,12 @@ jobs:
           - arm64
           # - armhf # TODO Enable when supported
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          # Relate-to: https://github.com/actions/checkout/pull/2081#2025
+          ref: ${{ github.ref }}
+
       - id: describe
         name: Describe HEAD
         run: >-

--- a/cmake/release-version.cmake
+++ b/cmake/release-version.cmake
@@ -1,1 +1,0 @@
-SET(GIT_VERSION "ver_1.7.0")


### PR DESCRIPTION
## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

    SWPROT-8953: ci: Pull annotated tag
    
    After further investigations, the reason that script failed to use
    the git describe in github it because of a bug in related github action
    
    Relate-to: https://github.com/actions/checkout/pull/2081
    Origin: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/42
    Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/35


## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


