### PR TITLE
    SWPROT-9320 Controller NLS state storage

### DIFF
--- a/applications/zpc/components/zpc_attribute_store/include/attribute_store_defined_attribute_types.h
+++ b/applications/zpc/components/zpc_attribute_store/include/attribute_store_defined_attribute_types.h
@@ -93,6 +93,11 @@ DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_FAILING_NODE_PING_INTERVAL, 0x0017)
 ///< Used by poll engine to request of for polling of the  attributer
 DEFINE_ATTRIBUTE(ATTRIBUTE_POLL_ENGINE_MARK, 0x0018)
 
+///< This represents whether a Z-Wave node supports NLS.
+DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_NLS_SUPPORT, 0x0019)
+///< This represents whether a Z-Wave node has NLS enabled.
+DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_NLS_STATE, 0x0020)
+
 // Generic endpoint attributes, should be attached under endpoints
 // Suggested range 0x100..0x1FF (using Z-Wave Protocol CC identifier)
 /** This represents the list of supported command classes (NIF) for a node */
@@ -107,10 +112,6 @@ DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_GENERIC_DEVICE_CLASS, 0x0104)
 DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_SPECIFIC_DEVICE_CLASS, 0x0105)
 ///< This represent a zwave_key_protocol_combination_t
 DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_KEY_AND_PROTOCOL_TO_DISCOVER, 0x0106)
-/** This represents whether a Z-Wave node/endpoint supports NLS. */
-DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_NLS_SUPPORT, 0x0107)
-/** This represents whether a Z-Wave node/endpoint has NLS enabled. */
-DEFINE_ATTRIBUTE(ATTRIBUTE_ZWAVE_NLS_STATE, 0x0108)
 
 // Generic attributes that can be placed anywhere under an endpoint.
 /** This indicates if more reports are expected to "complete" the value of an attribute */

--- a/applications/zpc/components/zpc_attribute_store/src/zpc_attribute_store_type_registration.cpp
+++ b/applications/zpc/components/zpc_attribute_store/src/zpc_attribute_store_type_registration.cpp
@@ -51,6 +51,8 @@ static const std::vector<attribute_schema_t> attribute_schema = {
   {ATTRIBUTE_MULTICAST_GROUP_LIST,   "Multicast Group list",   ATTRIBUTE_NODE_ID,   EMPTY_STORAGE_TYPE},
   {ATTRIBUTE_MULTICAST_GROUP,   "Multicast Group",   ATTRIBUTE_MULTICAST_GROUP_LIST,   U8_STORAGE_TYPE},
   {ATTRIBUTE_ZWAVE_FAILING_NODE_PING_INTERVAL,   "NOP interval",   ATTRIBUTE_NODE_ID,   UNSIGNED_LONG_STORAGE_TYPE},
+  {ATTRIBUTE_ZWAVE_NLS_SUPPORT,   "NLS support",   ATTRIBUTE_NODE_ID,   U8_STORAGE_TYPE},
+  {ATTRIBUTE_ZWAVE_NLS_STATE,   "NLS state",   ATTRIBUTE_NODE_ID,   U8_STORAGE_TYPE},
   {ATTRIBUTE_POLL_ENGINE_MARK,   "Poll Engine Mark",   ATTRIBUTE_STORE_INVALID_ATTRIBUTE_TYPE,   UNKNOWN_STORAGE_TYPE},
   /////////////////////////////////////////////////////////////////////
   //         Generic Z-Wave Endpoint ID attributes
@@ -61,8 +63,6 @@ static const std::vector<attribute_schema_t> attribute_schema = {
   {ATTRIBUTE_ZWAVE_GENERIC_DEVICE_CLASS,   "Generic Device Class",   ATTRIBUTE_ENDPOINT_ID,   U8_STORAGE_TYPE},
   {ATTRIBUTE_ZWAVE_SPECIFIC_DEVICE_CLASS,   "Specific Device Class",   ATTRIBUTE_ENDPOINT_ID,   U8_STORAGE_TYPE},
   {ATTRIBUTE_ZWAVE_KEY_AND_PROTOCOL_TO_DISCOVER,   "Network Key / Protocol to probe",   ATTRIBUTE_ENDPOINT_ID,   BYTE_ARRAY_STORAGE_TYPE},
-  {ATTRIBUTE_ZWAVE_NLS_SUPPORT,   "NLS support",   ATTRIBUTE_NODE_ID,   U8_STORAGE_TYPE},
-  {ATTRIBUTE_ZWAVE_NLS_STATE,   "NLS state",   ATTRIBUTE_NODE_ID,   U8_STORAGE_TYPE},
   /////////////////////////////////////////////////////////////////////
   //         Generic Z-Wave attributes
   /////////////////////////////////////////////////////////////////////

--- a/applications/zpc/components/zwave/zwave_transports/s2/CMakeLists.txt
+++ b/applications/zpc/components/zwave/zwave_transports/s2/CMakeLists.txt
@@ -57,6 +57,9 @@ if(BUILD_TESTING)
   add_mock(libs2_mock ${ZW-LIBS2_PATH}/include/S2.h
            ${ZW-LIBS2_PATH}/include/s2_inclusion.h
            ${ZW-LIBS2_PATH}/include/s2_protocol.h)
+  add_mock(libs2_external_mock ${ZW-LIBS2_PATH}/include/S2_external.h)
   target_interface_libraries(libs2_mock zwave_definitions s2crypto aes)
+  target_interface_libraries(libs2_external_mock zwave_definitions s2crypto aes)
   target_compile_definitions(libs2_mock PUBLIC ZIPGW)
+  target_compile_definitions(libs2_external_mock PUBLIC ZIPGW)
 endif()

--- a/applications/zpc/components/zwave/zwave_transports/s2/src/zwave_s2_transport.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/src/zwave_s2_transport.c
@@ -453,7 +453,23 @@ void S2_notify_nls_state_report(node_t srcNode, uint8_t class_id, bool nls_capab
 
 void S2_save_nls_state(void)
 {
-  // not relevant for ZPC
+  zwave_node_id_t node_id = zwave_network_management_get_node_id();
+
+  sl_status_t status = zwave_store_nls_state(node_id, s2_ctx->nls_state, REPORTED_ATTRIBUTE);
+  if (status != SL_STATUS_OK) {
+    sl_log_error(LOG_TAG, "Unable to save NLS state in attribute store for Node ID: %d\n", node_id);
+    return;
+  }
+
+  if (s2_ctx->nls_state) {
+    status = zwapi_enable_node_nls(node_id);
+    if (SL_STATUS_OK != status) {
+      sl_log_error(LOG_TAG, "Error saving NLS state in the controller NVM for Node ID: %d", node_id);
+      return;
+    }
+  }
+
+  sl_log_debug(LOG_TAG, "NLS state saved in the controller NVM for Node ID: %d\n", node_id);
 }
 
 sl_status_t compute_next_nls_enabled_node(void)

--- a/applications/zpc/components/zwave/zwave_transports/s2/test/CMakeLists.txt
+++ b/applications/zpc/components/zwave/zwave_transports/s2/test/CMakeLists.txt
@@ -42,6 +42,7 @@ target_add_unittest(
   zwave_s2_network_test.c
   DEPENDS
   libs2_mock
+  libs2_external_mock
   zwave_network_management_mock
   zwave_api_mock
   uic_contiki_stub

--- a/applications/zpc/components/zwave/zwave_transports/s2/test/zwave_s2_network_test.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/test/zwave_s2_network_test.c
@@ -17,10 +17,12 @@
 
 #include "S2_mock.h"
 #include "s2_inclusion_mock.h"
+#include "S2_external_mock.h"
 #include "zwave_s2_network.h"
 #include "zwave_s2_network_callbacks_mock.h"
 #include "sl_log.h"
 #include "zwapi_protocol_mem_mock.h"
+#include "zwapi_protocol_controller_mock.h"
 
 // Includes from LibS2
 #include "s2_protocol.h"
@@ -53,6 +55,7 @@ void setUp()
   // Configure our HomeID and NodeID for the test:
   zwave_network_management_get_home_id_IgnoreAndReturn(test_home_id);
   zwave_network_management_get_node_id_IgnoreAndReturn(test_node_id);
+  clock_time_IgnoreAndReturn(0);
   s2_ctx = &test_ctx;
   memset(s2_ctx, 0, sizeof(struct S2));
   contiki_test_helper_init();
@@ -74,6 +77,8 @@ static void
 
 void test_s2_network_init()
 {
+  uint8_t nls_state = false;
+
   S2_destroy_Expect(s2_ctx);
   s2_inclusion_init_IgnoreAndReturn(true);
   s2_inclusion_set_event_handler_StubWithCallback(
@@ -81,6 +86,9 @@ void test_s2_network_init()
   S2_init_ctx_IgnoreAndReturn(0);
 
   zwapi_memory_get_buffer_IgnoreAndReturn(SL_STATUS_OK);
+
+  zwapi_get_node_nls_ExpectAndReturn(1, &nls_state, SL_STATUS_OK);
+  S2_load_nls_state_Ignore();
 
   zwave_s2_network_init();
 }


### PR DESCRIPTION
    SWPROT-9320 Controller NLS state storage
    
    Merge in UIC/uic from task/ayersoz/SWPROT-9320-controller-nls-state-storage to z-wave/main
    
    (cherry picked from commit 7a63883eb991f0f8cbbb663df8802be0764ec6e5)
    Last-Update: 2025-03-05



## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


