### PR TITLE
libs2/tf: Fix a/z/c/z/z/s/l/z/T/cmock submodule to v2.5.3-g9d092898

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/TestFramework/cmock"]
+	path = applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/TestFramework/cmock
+	url = https://github.com/throwtheswitch/cmock


### PR DESCRIPTION
Observed issue on ver_1.7.0-27-g1302b2a5 was:

    docker build https://github.com/SiliconLabsSoftware/z-wave-protocol-controller.git#main
    unable to prepare context: unable to 'git clone' to temporary context directory: \
      error initializing submodules: fatal: No url found for submodule path \
        'applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/TestFramework/cmock' in .gitmodules

This was done using:

    git submodule add --force \
      https://github.com/throwtheswitch/cmock \
      applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/TestFramework/cmock

     git -C applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/TestFramework/cmock \
        checkout v2.5.3-g9d092898

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/57#issuecomment-2704286308

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


