### PR TITLE
tests: Fix a/z/c/z/test/zwave_command_class_time_parameters_test on U…

### DIFF
--- a/applications/zpc/components/zwave_command_classes/test/CMakeLists.txt
+++ b/applications/zpc/components/zwave_command_classes/test/CMakeLists.txt
@@ -54,8 +54,10 @@ target_add_unittest(
     zwave_command_class_time_parameters_test.c
     DEPENDS
     zwave_command_class_test_helpers
-    ${MOCK_LIBS})
-if(${BUILD_TESTING_PROPERTY_DISABLED})
+    ${MOCK_LIBS}
+)
+if(${ZPC_BUILD_TESTING_PROPERTY_DISABLED})
+  message(WARNING "Please fix this test")
   set_tests_properties(zwave_command_class_time_parameters_test
     PROPERTIES DISABLED True)
 endif()

--- a/applications/zpc/components/zwave_command_classes/test/zwave_command_class_time_parameters_test.c
+++ b/applications/zpc/components/zwave_command_classes/test/zwave_command_class_time_parameters_test.c
@@ -11,6 +11,7 @@
  *
  *****************************************************************************/
 
+#include <stdlib.h>
 #include <time.h>
 #include <sys/time.h>
 #include <string.h>
@@ -48,7 +49,9 @@ struct tm test_time_info = {.tm_year  = TEST_YEAR - 1900,
                             .tm_isdst = -1};
 
 /// Setup the test suite (called once before all test_xxx functions are called)
-void suiteSetUp() {}
+void suiteSetUp() {
+  setenv("TZ", "UTC", 1);
+}
 
 /// Teardown the test suite (called once after all test_xxx functions are called)
 int suiteTearDown(int num_failures)


### PR DESCRIPTION
tests: Fix a/z/c/z/test/zwave_command_class_time_parameters_test UTC #46

This test was previously bypassed, it is now working as expected.

The reason it was failing is because mktime use timezone
to set the tm structure that will be returned to the next step of test.

Setting timezone to UTC (+0) solves the problem.

BTW, I am introducing an (unused) variable to keep the property tweek on fishy tests
if needed later, it could be removed on next cmake update.

Bug-SiliconLabsSoftware: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/46
Origin: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/69