### PR TITLE
SWPROT-9430: Update Get Node NLS State SAPI command

### DIFF
--- a/applications/zpc/components/zpc_stdin/src/zpc_stdin_command_handling.cpp
+++ b/applications/zpc/components/zpc_stdin/src/zpc_stdin_command_handling.cpp
@@ -878,16 +878,16 @@ static sl_status_t handle_get_nls_state(const handle_args_t &arg)
     zwave_node_id_t node_id
       = static_cast<zwave_node_id_t>(std::stoi(arg[1].c_str(), nullptr, 10));
     uint8_t nls_state = 0;
-    sl_status_t status = zwapi_get_node_nls(node_id, &nls_state);
+    uint8_t nls_support = 0;
+    sl_status_t status = zwapi_get_node_nls(node_id, &nls_state, &nls_support);
     if (SL_STATUS_OK == status)
     {
-      // TODO: Add commented condition below once related SAPI command is updated
-      status = zwave_store_nls_state(node_id, nls_state, REPORTED_ATTRIBUTE) /* || zwave_store_nls_support(node_id, nls_support, REPORTED_ATTRIBUTE) */;
+      status = zwave_store_nls_state(node_id, nls_state, REPORTED_ATTRIBUTE) || zwave_store_nls_support(node_id, nls_support, REPORTED_ATTRIBUTE);
       if (SL_STATUS_OK != status) {
         dprintf(out_stream, "Unable to store NLS state for Node ID: %d\n", node_id);
         return SL_STATUS_FAIL;
       }
-      dprintf(out_stream, "Node ID %d, NLS state: %d\n", node_id, nls_state);
+      dprintf(out_stream, "Node ID %d, NLS Support: %d, NLS state: %d\n", node_id, nls_support, nls_state);
       return SL_STATUS_OK;
     }
     else

--- a/applications/zpc/components/zpc_stdin/test/zpc_stdin_test.c
+++ b/applications/zpc/components/zpc_stdin/test/zpc_stdin_test.c
@@ -333,8 +333,8 @@ void test_handle_cc_versions_log()
 void test_handle_nls()
 {
   sl_status_t state;
-  uint8_t nls_state = false;
-  uint8_t nls_support = false;
+  uint8_t nls_state = 0;
+  uint8_t nls_support = 0;
 
   state = uic_stdin_handle_command("zwave_enable_nls");
   TEST_ASSERT_EQUAL(SL_STATUS_FAIL, state);

--- a/applications/zpc/components/zpc_stdin/test/zpc_stdin_test.c
+++ b/applications/zpc/components/zpc_stdin/test/zpc_stdin_test.c
@@ -334,6 +334,7 @@ void test_handle_nls()
 {
   sl_status_t state;
   uint8_t nls_state = false;
+  uint8_t nls_support = false;
 
   state = uic_stdin_handle_command("zwave_enable_nls");
   TEST_ASSERT_EQUAL(SL_STATUS_FAIL, state);
@@ -345,8 +346,9 @@ void test_handle_nls()
   state = uic_stdin_handle_command("zwave_get_nls_state");
   TEST_ASSERT_EQUAL(SL_STATUS_FAIL, state);
 
-  zwapi_get_node_nls_ExpectAndReturn(2, &nls_state, SL_STATUS_OK);
+  zwapi_get_node_nls_ExpectAndReturn(2, &nls_state, &nls_support, SL_STATUS_OK);
   zwave_store_nls_state_ExpectAndReturn(2, nls_state, REPORTED_ATTRIBUTE, SL_STATUS_OK);
+  zwave_store_nls_support_ExpectAndReturn(2, nls_support, REPORTED_ATTRIBUTE, SL_STATUS_OK);
   state = uic_stdin_handle_command("zwave_get_nls_state 2");
   TEST_ASSERT_EQUAL(SL_STATUS_OK, state);
 }

--- a/applications/zpc/components/zwave/zwave_transports/s2/src/zwave_s2_network.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/src/zwave_s2_network.c
@@ -148,8 +148,7 @@ void zwave_s2_network_init()
     return;
   }
 
-  sl_log_info(LOG_TAG, "NLS support %s for Node ID: %d\n", nls_support == 1 ? "supported" : "not supported", node_id);
-  sl_log_info(LOG_TAG, "NLS state %s for Node ID: %d\n", nls_state == 1 ? "active" : "not active", node_id);
+  sl_log_info(LOG_TAG, "NLS %s, NLS %s for Node ID: %d\n", nls_support == 0 ? "not supported" : "supported", nls_state == 0 ? "not active" : "active", node_id);
 
   S2_load_nls_state(s2_ctx, nls_state);
   status = zwave_store_nls_state(node_id, nls_state, REPORTED_ATTRIBUTE) || zwave_store_nls_support(node_id, nls_support, REPORTED_ATTRIBUTE);

--- a/applications/zpc/components/zwave/zwave_transports/s2/src/zwave_s2_network.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/src/zwave_s2_network.c
@@ -139,20 +139,22 @@ void zwave_s2_network_init()
   zwave_s2_log_security_keys(SL_LOG_INFO);
 #endif
 
+  uint8_t nls_support = 0;
   uint8_t nls_state = 0;
   zwave_node_id_t node_id = zwave_network_management_get_node_id();
-  sl_status_t status = zwapi_get_node_nls(node_id, &nls_state);
+  sl_status_t status = zwapi_get_node_nls(node_id, &nls_state, &nls_support);
   if (status != SL_STATUS_OK) {
     sl_log_error(LOG_TAG, "Unable to read NLS state for Node ID: %d\n", node_id);
     return;
   }
 
+  sl_log_info(LOG_TAG, "NLS support %s for Node ID: %d\n", nls_support == 1 ? "supported" : "not supported", node_id);
   sl_log_info(LOG_TAG, "NLS state %s for Node ID: %d\n", nls_state == 1 ? "active" : "not active", node_id);
 
   S2_load_nls_state(s2_ctx, nls_state);
-  status = zwave_store_nls_state(node_id, nls_state, REPORTED_ATTRIBUTE);
+  status = zwave_store_nls_state(node_id, nls_state, REPORTED_ATTRIBUTE) || zwave_store_nls_support(node_id, nls_support, REPORTED_ATTRIBUTE);
   if (status != SL_STATUS_OK) {
-    sl_log_error(LOG_TAG, "Unable to store NLS state in attribute store for Node ID: %d\n", node_id);
+    sl_log_error(LOG_TAG, "Unable to store NLS state/support in attribute store for Node ID: %d\n", node_id);
   }
 }
 

--- a/applications/zpc/components/zwave/zwave_transports/s2/test/zwave_s2_network_test.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/test/zwave_s2_network_test.c
@@ -78,6 +78,7 @@ static void
 void test_s2_network_init()
 {
   uint8_t nls_state = false;
+  uint8_t nls_support = false;
 
   S2_destroy_Expect(s2_ctx);
   s2_inclusion_init_IgnoreAndReturn(true);
@@ -87,7 +88,7 @@ void test_s2_network_init()
 
   zwapi_memory_get_buffer_IgnoreAndReturn(SL_STATUS_OK);
 
-  zwapi_get_node_nls_ExpectAndReturn(1, &nls_state, SL_STATUS_OK);
+  zwapi_get_node_nls_ExpectAndReturn(1, &nls_state, &nls_support, SL_STATUS_OK);
   S2_load_nls_state_Ignore();
 
   zwave_s2_network_init();

--- a/applications/zpc/components/zwave_api/include/zwapi_protocol_controller.h
+++ b/applications/zpc/components/zwave_api/include/zwapi_protocol_controller.h
@@ -1049,6 +1049,8 @@ sl_status_t zwapi_enable_node_nls(const zwave_node_id_t nodeId);
  * @brief Get the NLS State of the node in the controller NVM 
  * 
  * @param nodeId the node ID
+ * @param nls_state NLS state pointer to be filled
+ * @param nls_support NLS support pointer to be filled
  * 
  */
 sl_status_t zwapi_get_node_nls(const zwave_node_id_t nodeId, uint8_t* nls_state, uint8_t* nls_support);

--- a/applications/zpc/components/zwave_api/include/zwapi_protocol_controller.h
+++ b/applications/zpc/components/zwave_api/include/zwapi_protocol_controller.h
@@ -1051,7 +1051,7 @@ sl_status_t zwapi_enable_node_nls(const zwave_node_id_t nodeId);
  * @param nodeId the node ID
  * 
  */
-sl_status_t zwapi_get_node_nls(const zwave_node_id_t nodeId, uint8_t* nls_state);
+sl_status_t zwapi_get_node_nls(const zwave_node_id_t nodeId, uint8_t* nls_state, uint8_t* nls_support);
 
 /**
  * @brief Get the NLS State of the nodes of a network in the controller NVM 

--- a/applications/zpc/components/zwave_api/src/zwapi_protocol_controller.c
+++ b/applications/zpc/components/zwave_api/src/zwapi_protocol_controller.c
@@ -829,6 +829,9 @@ sl_status_t zwapi_get_node_nls(
   {
     *nls_support = response_buffer[IDX_DATA];
     *nls_state = response_buffer[IDX_DATA + 1];
+    if (((*nls_support != 0) && (*nls_support != 1)) || ((*nls_state != 0) && (*nls_state != 1))) {
+      return SL_STATUS_FAIL;
+    }
     return SL_STATUS_OK;
   }
 

--- a/applications/zpc/components/zwave_api/src/zwapi_protocol_controller.c
+++ b/applications/zpc/components/zwave_api/src/zwapi_protocol_controller.c
@@ -810,7 +810,8 @@ sl_status_t zwapi_enable_node_nls(const zwave_node_id_t nodeId)
 
 sl_status_t zwapi_get_node_nls(
   const zwave_node_id_t nodeId,
-  uint8_t* nls_state)
+  uint8_t* nls_state,
+  uint8_t* nls_support)
 {
   uint8_t response_length = 0;
   uint8_t index = 0;
@@ -826,8 +827,9 @@ sl_status_t zwapi_get_node_nls(
 
   if (send_command_status == SL_STATUS_OK && response_length > IDX_DATA)
   {
-    *nls_state = response_buffer[IDX_DATA];
-    return SL_STATUS_OK;    
+    *nls_support = response_buffer[IDX_DATA];
+    *nls_state = response_buffer[IDX_DATA + 1];
+    return SL_STATUS_OK;
   }
 
   return SL_STATUS_FAIL;

--- a/applications/zpc/components/zwave_api/test/zwapi_protocol_controller_test.c
+++ b/applications/zpc/components/zwave_api/test/zwapi_protocol_controller_test.c
@@ -65,15 +65,18 @@ void test_zwapi_enable_node_nls(void)
 void test_zwapi_get_node_nls(void)
 {
   zwave_node_id_t node_id = 2;
+  uint8_t nls_supported = 1;
   uint8_t nls_enabled = 1;
   uint8_t response_buffer[]     = {0x04 /* length = len(payload) + 3 */,
                                    0x01 /* type: response */,
                                    FUNC_ID_ZW_GET_NODE_NLS_STATE /* cmd */,
+                                   nls_supported,
                                    nls_enabled /* payload */};
-  uint8_t response_length       = 4;
+  uint8_t response_length       = 5;
   uint8_t payload_buffer[] = {0x02};
   uint8_t payload_buffer_length = 1;
   uint8_t node_nls_state        = 99;
+  uint8_t node_nls_support      = 99;
 
   zwapi_session_send_frame_with_response_ExpectAndReturn(
     FUNC_ID_ZW_GET_NODE_NLS_STATE,
@@ -90,7 +93,7 @@ void test_zwapi_get_node_nls(void)
   zwapi_session_send_frame_with_response_ReturnThruPtr_response_len(
     &response_length);
 
-  TEST_ASSERT_EQUAL(SL_STATUS_OK, zwapi_get_node_nls(node_id, &node_nls_state));
+  TEST_ASSERT_EQUAL(SL_STATUS_OK, zwapi_get_node_nls(node_id, &node_nls_state, &node_nls_support));
   TEST_ASSERT_EQUAL(nls_enabled, node_nls_state);
 }
 


### PR DESCRIPTION
## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

Specification change has been merged:
https://github.com/Z-Wave-Alliance/CSWG/blob/5f137ca1867a359a0523d63d9b2bd1bf2233f4d4/documents/zw-host-api-spec/source/zwave_api_commands/network_management/controller_nodes/get_node_nls_state_command.rst#L4


## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [x] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


