### PR TITLE
docker: Slim down run image to save space for github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,21 @@ jobs:
           | tee $GITHUB_OUTPUT
       - name: Build Docker image from sources
         run: >-
+          df -h
+          &&
           docker build
           --tag "${{ env.project-name }}:latest"
           --build-arg UNIFYSDK_GIT_REPOSITORY=${{ secrets.UNIFYSDK_GIT_REPOSITORY }}
           --build-arg UNIFYSDK_GIT_TAG=${{ secrets.UNIFYSDK_GIT_TAG }}
           .
+          &&
+          df -h
+
       - name: Extract artifacts
         run: >-
           container=$(docker create "${{ env.project-name }}:latest")
           && docker cp
-          ${container}:/usr/local/opt/${{ env.project-name }}/build/dist .
+          ${container}:/usr/local/opt/${{ env.project-name }}/dist .
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/cmake/modules/FindUnifySDK.cmake
+++ b/cmake/modules/FindUnifySDK.cmake
@@ -34,6 +34,7 @@ file(GLOB UNIFYSDK_PATCHES
   ${PROJECT_SOURCE_DIR}/patches/UnifySDK/*.patch
 )
 
+set(ENV{GIT_LFS_SKIP_SMUDGE} "1")
 find_package(Git)
 FetchContent_Declare(
   UnifySDK
@@ -41,6 +42,7 @@ FetchContent_Declare(
   GIT_TAG        ${UNIFYSDK_GIT_TAG}
   GIT_SUBMODULES_RECURSE True
   GIT_SHALLOW 1
+  GIT_PROGRESS True
 
   # Prevent "fatal: unable to auto-detect email address"
   GIT_CONFIG user.email=nobody@UnifySDK.localhost


### PR DESCRIPTION
Those changes were motivated to github

This extra clean step saves 3GB (11GB to 7.6GB, which is still huge)

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/10
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/15
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/7
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/2

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


