### PR TITLE
Include header algorithms to enable build with g++-14

### DIFF
--- a/applications/zpc/components/zwave_command_classes/src/zwave_command_class_crc16.cpp
+++ b/applications/zpc/components/zwave_command_classes/src/zwave_command_class_crc16.cpp
@@ -17,6 +17,7 @@
 // Generic includes
 #include <stdlib.h>
 #include <assert.h>
+#include <algorithm>
 #include <utility> // make_pair
 
 // Includes from other ZPC Components


### PR DESCRIPTION
## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->


G++-14 was not building because "std::find_if" was missing the header \<algorithm\>.

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement