### PR TITLE
ci: github: Align docker image to zpc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,15 @@ on:  # yamllint disable-line rule:truthy
       - completed
 jobs:
   test:
+    env:
+      project-name: z-wave-protocol-controller  # Align to docker (lowercase)
     runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download image
         uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
-          image: "${{ github.event.repository.name }}:latest"
+          image: "${{ env.project-name }}:latest"
           workflow: "build"
           token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
@@ -55,7 +57,7 @@ jobs:
         run: |
           set -x
           export ZPC_RUN_MODE="docker"
-          export ZPC_COMMAND="docker run ${{ github.event.repository.name }}"
+          export ZPC_COMMAND="docker run ${{ env.project-name }}"
           $ZPC_COMMAND --version
           docker-compose pull
           export ZPC_COMMAND="docker-compose up --abort-on-container-exit"


### PR DESCRIPTION
This is a workaround, to allow other related developements (in other repos not forks).

To be reverted once everything agregrated in the upstream.

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/2

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


