### PR TITLE
fix(github): Use build git rev for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@
 ---
 
 name: test
+run-name: "test: ${{ github.event.workflow_run.head_branch }}#${{ github.event.workflow_run.head_commit.id }}"
 
 on:  # yamllint disable-line rule:truthy
   workflow_run:
@@ -28,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_commit.id }}
 
       - name: Download embedded applications package
         uses: robinraju/release-downloader@v1.12


### PR DESCRIPTION
While the actions are working as expected in main branch I noticed that for other branches:
In test workflow the checkout action is not using the same rev as in the build workflow. IHMO this is an odd default beaviour...

Relate-to: https://github.com/orgs/community/discussions/157893
Realte-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/22

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


