### PR TITLE
ci: github: Propagate test run outcome to commit status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@
 ---
 
 name: test
+
+# yamllint disable-line rule:line-length
 run-name: "test: ${{ github.event.workflow_run.head_branch }}#${{ github.event.workflow_run.head_commit.id }}"
 
 on:  # yamllint disable-line rule:truthy
@@ -11,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
     workflows: ["build"]
     types:
       - completed
+
 jobs:
   test:
     env:
@@ -57,6 +60,7 @@ jobs:
           && date -u
 
       - name: Run
+        id: run
         run: |
           set -x
           export ZPC_RUN_MODE="docker"
@@ -67,3 +71,20 @@ jobs:
           cd z-wave-stack-binaries/bin && file -E *_x86_REALTIME.elf && cd -
           export ZPC_ARGS="--log.level=d"
           ./scripts/tests/z-wave-stack-binaries-test.sh
+        continue-on-error: true
+
+      - name: Propagate run status to commit status
+        uses: actions/github-script@v7
+        if: always()
+        env:
+          status: ${{ steps.run.outcome }}
+          sha: ${{ github.event.workflow_run.head_commit.id }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: context.sha,
+            state: process.env.status
+            })
+            process.exit(process.env.status == 'success' ? 0 : 1);


### PR DESCRIPTION
The change allows to block failed PRs

Relate-to: https://github.com/actions/github-script
Relate-to: https://octokit.github.io/rest.js/v21/#repos
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/22

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


