### PR TITLE
ci: github: Restrict permissions for actions, test update commit status

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -8,6 +8,8 @@ on:  # yamllint disable-line rule:truthy
       - '*'
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   build:
+    permissions:
+      contents: read
     env:
       project-name: z-wave-protocol-controller  # Align to docker (lowercase)
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   test:
+    permissions:
+      contents: read
+      statuses: write
     env:
       project-name: z-wave-protocol-controller  # Align to docker (lowercase)
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Observed issue is:

    Run actions/github-script@v7
    (...)
    RequestError [HttpError]: Resource not accessible by integration
    (...)
    status: 403,
    response: {
    (...)
    request: {
    method: 'POST',
    url: 'https://api.github.com/repos/SiliconLabsSoftware/z-wave-protocol-controller/statuses/***',
    (...)

This is caused by the repo configuration (in actions):

    "Workflow permissions" : "Read repository contents and packages permissions"

Which is more restrictive that default:

    "Workflow permissions" : "Read and write permissions"

There is no need to set perm in token anymore.

Extra note, to some extends tokens may be replaced with GH apps.

Relate-to: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status Relate-to:https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/67 Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/settings/actions

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


