### PR TITLE
ci: github: Fix change status of head of failed run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            sha: context.sha,
+            sha: process.env.sha,
             state: process.env.status
             })
             process.exit(process.env.status == 'success' ? 0 : 1);


### PR DESCRIPTION
Currently it touched the commit of the workflow (head of main)

It was tested with related PR:

Relate-to: https://github.com/rzr/z-wave-protocol-controller/pull/4
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/67
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/settings/actions

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


