### PR TITLE
ci: github: Harden the test workflow by downloading into temp dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download image
+        id: image
         # yamllint disable-line rule:line-length
         uses: ishworkh/container-image-artifact-download@ccb3671db007622e886a2d7037eb62b119d5ffaf  # v2.0.0
         with:
@@ -32,7 +33,18 @@ jobs:
           workflow: "build"
           token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
-
+      - name: Check and remove downloaded artifact
+        # yamllint disable rule:line-length
+        run: |
+          set -xe
+          file="/tmp/action_image_artifact_${{ github.event.repository.name }}_latest/${{ github.event.repository.name }}_latest"
+          echo "Info for comparing to build artifacts"
+          sha256sum "${file}"
+          tar -xOf "${file}" manifest.json | jq
+          echo "TODO: https://github.com/ishworkh/container-image-artifact-download/issues/7#issuecomment-2904751460"
+          rm -rfv "${file}"
+          echo "TODO: https://docs.docker.com/engine/security/trust/"
+        # yamllint enable rule:line-length
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -59,14 +71,15 @@ jobs:
           ${{ env.debian_packages }}
           && sudo apt-get clean -y
           && echo "https://github.com/Z-Wave-Alliance/z-wave-stack/issues/733"
-          && mkdir -p z-wave-stack-binaries
+          && mkdir -p ${{ runner.temp }}/z-wave-stack-binaries
           && tar xfz z-wave-stack-binaries-*-Linux.tar.gz
-          -C z-wave-stack-binaries
+          -C ${{ runner.temp }}/z-wave-stack-binaries
           && rm z-wave-stack-binaries-*-Linux.tar.gz
           && date -u
 
       - name: Run
         id: run
+        # yamllint disable rule:line-length
         run: |
           set -x
           export ZPC_RUN_MODE="docker"
@@ -74,9 +87,10 @@ jobs:
           $ZPC_COMMAND --version
           docker-compose pull
           export ZPC_COMMAND="docker-compose up --abort-on-container-exit"
-          cd z-wave-stack-binaries/bin && file -E *_x86_REALTIME.elf && cd -
+          export z_wave_stack_binaries_bin_dir="${{ runner.temp }}/z-wave-stack-binaries/bin"
           export ZPC_ARGS="--log.level=d"
           ./scripts/tests/z-wave-stack-binaries-test.sh
+        # yamllint enable rule:line-length
         continue-on-error: true
 
       - name: Propagate run status to commit status


### PR DESCRIPTION
This issue was reported by CodeQL, IMHOI the alert was over reacting because contents was already extracted in a separate directory (which is absent in tree, so there is no risk to override)

An extra check would be to verify a signed asset (using GPG), along a ZWA public key shared in tree.

Potential fix for code scanning alert no. 1: Artifact poisoning

Origin: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/107

Relate-to: https://github.com/Z-Wave-Alliance/OSWG/issues/48#issuecomment-2607661260
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/67
Relate-to: https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/1
Relate-to: https://cwe.mitre.org/data/definitions/829.html

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


