### PR TITLE
fix(cc): Fix meter_control_test check on frame without cmd

### DIFF
--- a/applications/zpc/components/zwave_command_classes/src/zwave_command_class_meter_control.c
+++ b/applications/zpc/components/zwave_command_classes/src/zwave_command_class_meter_control.c
@@ -742,7 +742,7 @@ static sl_status_t zwave_command_class_meter_control_handler(
   const uint8_t *frame,
   uint16_t frame_length)
 {
-  if (frame_length < COMMAND_INDEX) {
+  if (frame_length <= COMMAND_INDEX) {
     return SL_STATUS_NOT_SUPPORTED;
   }
 

--- a/applications/zpc/components/zwave_command_classes/test/zwave_command_class_meter_control_test.c
+++ b/applications/zpc/components/zwave_command_classes/test/zwave_command_class_meter_control_test.c
@@ -854,13 +854,16 @@ void test_meter_report_too_short()
 void test_meter_command_class_no_command()
 {
   // Simulate a frame
-  const uint8_t incoming_frame[] = {COMMAND_CLASS_METER};
+  const uint8_t incoming_frame[] = {COMMAND_CLASS_METER,
+      METER_REPORT_V5, // Add deterministic valid value for overflow check
+    };
 
   TEST_ASSERT_NOT_NULL(meter_handler.control_handler);
   TEST_ASSERT_EQUAL(SL_STATUS_NOT_SUPPORTED,
                     meter_handler.control_handler(&info,
                                                   incoming_frame,
-                                                  sizeof(incoming_frame)));
+                                                  sizeof(incoming_frame) -1 // Remove padding
+                        ));
 }
 
 void test_supported_rate_types_unknown_values()


### PR DESCRIPTION
Also fix related test, to always fail:

102 - zwave_command_class_meter_control_test (Failed)

For some reason I dont remember seeing it failed
despite the read should be invalid, this should be triggered by CI



Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/110#issuecomment-2916504388
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/111#issuecomment-2916256186
Thanks-to: Laudin Molina Troconis <laudin.molinatroconis@silabs.com>
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/10

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


