### PR TITLE
z_api_demo: Harden zwave_api_demo_commands.c by checking snprintf

### DIFF
--- a/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_commands.c
+++ b/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_commands.c
@@ -12,6 +12,7 @@
  *****************************************************************************/
 
 #include "zwave_api_demo.h"
+#include <assert.h>
 #include <string.h>
 
 extern bool exit_program;
@@ -307,18 +308,32 @@ static sl_status_t request_nif()
 static sl_status_t node_list()
 {
   zwave_nodemask_t node_list = {0};
-
+  int written                = 0;
   sl_status_t command_status = zwapi_get_node_list(node_list);
   if (command_status == SL_STATUS_OK) {
     char message[MAXIMUM_MESSAGE_SIZE];
     uint16_t index = 0;
-    index
-      += snprintf(message + index, sizeof(message) - index, "NodeID List: ");
+
+    written
+      = snprintf(message + index, sizeof(message) - index, "NodeID List: ");
+    if (written < 0 || written >= (int)(sizeof(message) - index)) {
+      sl_log_error(LOG_TAG, "Overflow in node_list\n");
+      assert(false);
+      return SL_STATUS_WOULD_OVERFLOW;
+    }
+    index += written;
+
     for (zwave_node_id_t node_id = ZW_MIN_NODE_ID; node_id <= ZW_LR_MAX_NODE_ID;
          node_id++) {
       if (ZW_IS_NODE_IN_MASK(node_id, node_list) == 1) {
-        index
-          += snprintf(message + index, sizeof(message) - index, "%d ", node_id);
+        written
+          = snprintf(message + index, sizeof(message) - index, "%d ", node_id);
+        if (written < 0 || written >= (int)(sizeof(message) - index)) {
+          sl_log_error(LOG_TAG, "Overflow in node_list\n");
+          assert(false);
+          return SL_STATUS_WOULD_OVERFLOW;
+        }
+        index += written;
       }
     }
     sl_log_info(LOG_TAG, "%s\n", message);
@@ -337,15 +352,28 @@ static sl_status_t failed_node_list()
   }
   char message[MAXIMUM_MESSAGE_SIZE];
   uint16_t index = 0;
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "Failed NodeID List: ");
+  int written    = snprintf(message + index,
+                         sizeof(message) - index,
+                         "Failed NodeID List: ");
+  if (written < 0 || written >= (int)(sizeof(message) - index)) {
+    sl_log_error(LOG_TAG, "Overflow in failed_node_list\n");
+    assert(false);
+    return SL_STATUS_WOULD_OVERFLOW;
+  }
+  index += written;
+
   for (zwave_node_id_t node_id = ZW_MIN_NODE_ID; node_id <= ZW_LR_MAX_NODE_ID;
        node_id++) {
     if (ZW_IS_NODE_IN_MASK(node_id, node_list) == 1) {
       if (zwapi_is_node_failed(node_id)) {
-        index
-          += snprintf(message + index, sizeof(message) - index, "%d ", node_id);
+        written
+          = snprintf(message + index, sizeof(message) - index, "%d ", node_id);
+        if (written < 0 || written >= (int)(sizeof(message) - index)) {
+          sl_log_error(LOG_TAG, "Overflow in failed_node_list\n");
+          assert(false);
+          return SL_STATUS_WOULD_OVERFLOW;
+        }
+        index += written;
       }
     }
   }
@@ -359,17 +387,31 @@ static sl_status_t virtual_node_list()
   zwave_nodemask_t node_list = {0};
 
   sl_status_t command_status = zwapi_get_virtual_nodes(node_list);
+  int written                = 0;
   if (command_status == SL_STATUS_OK) {
     char message[MAXIMUM_MESSAGE_SIZE];
     uint16_t index = 0;
-    index += snprintf(message + index,
-                      sizeof(message) - index,
-                      "Virtual NodeID List: ");
+    written        = snprintf(message + index,
+                       sizeof(message) - index,
+                       "Virtual NodeID List: ");
+    if (written < 0 || written >= (int)(sizeof(message) - index)) {
+      sl_log_error(LOG_TAG, "Overflow in virtual_node_list\n");
+      assert(false);
+      return SL_STATUS_WOULD_OVERFLOW;
+    }
+    index += written;
+
     for (zwave_node_id_t node_id = ZW_MIN_NODE_ID; node_id <= ZW_LR_MAX_NODE_ID;
          node_id++) {
       if (ZW_IS_NODE_IN_MASK(node_id, node_list) == 1) {
-        index
-          += snprintf(message + index, sizeof(message) - index, "%d ", node_id);
+        written
+          = snprintf(message + index, sizeof(message) - index, "%d ", node_id);
+        if (written < 0 || written >= (int)(sizeof(message) - index)) {
+          sl_log_error(LOG_TAG, "Overflow in virtual_node_list\n");
+          assert(false);
+          return SL_STATUS_WOULD_OVERFLOW;
+        }
+        index += written;
       }
     }
     sl_log_info(LOG_TAG, "%s\n", message);


### PR DESCRIPTION
Checking snprintf results, reminder :

       If the output was truncated due to this limit, then the return
       value is the number of characters (excluding the terminating
       null byte) which would have been written to the final string if
       enough space had been available

This was found using CodeQL:

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/100

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


