### PR TITLE
utils: Harden zpc_converters.c by checking snprintf

### DIFF
--- a/applications/zpc/components/zpc_utils/src/zpc_converters.c
+++ b/applications/zpc/components/zpc_utils/src/zpc_converters.c
@@ -18,8 +18,7 @@
 #include <errno.h>
 #include <stdio.h>
 
-sl_status_t zpc_converters_dsk_str_to_internal(const char *src,
-                                               zwave_dsk_t dst)
+sl_status_t zpc_converters_dsk_str_to_internal(const char *src, zwave_dsk_t dst)
 {
   unsigned int dst_idx = 0;
   const char *idx      = src;
@@ -51,8 +50,13 @@ sl_status_t zpc_converters_dsk_to_str(const zwave_dsk_t src,
   }
   size_t index = 0;
   for (int i = 0; i < sizeof(zwave_dsk_t); i += 2) {
-    int d = (src[i] << 8) | src[i + 1];
-    index += snprintf(&dst[index], dst_max_len - index, "%05i-", d);
+    int d       = (src[i] << 8) | src[i + 1];
+    int written = snprintf(&dst[index], dst_max_len - index, "%05i-", d);
+    if (written < 0 || written >= dst_max_len - index) {
+      assert(false);
+      return SL_STATUS_WOULD_OVERFLOW;
+    }
+    index += written;
   }
   // Erase the last "-"
   if (index > 0) {


### PR DESCRIPTION
Checking snprintf results, reminder :

    If the output was truncated due to this limit, then the return
    value is the number of characters (excluding the terminating
    null byte) which would have been written to the final string if
    enough space had been available

This was found using CodeQL:

    Potential fix for code scanning alert no. 12:
    Potentially overflowing call to snprintf

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/100

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


