### PR TITLE
fix(ci): tests: Prefer artfact over checkout action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,13 @@ jobs:
           # yamllint disable-line
           name: ${{ github.event.repository.name }}-${{ steps.describe.outputs.describe }}
           path: dist/
+
+      - name: Upload tests artifacts
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          # yamllint disable-line
+          name: ${{ github.event.repository.name }}-tests
+          path: |
+            scripts/tests
+            docker-compose.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,6 @@ jobs:
           rm -rfv "${{env.file}}"
           echo "TODO: https://docs.docker.com/engine/security/trust/"
         # yamllint enable rule:line-length
-      # yamllint disable-line rule:line-length
 
       - name: Download embedded applications package
         # yamllint disable-line rule:line-length
@@ -74,14 +73,21 @@ jobs:
           && rm z-wave-stack-binaries-*-Linux.tar.gz
           && date -u
 
-      - name: Download tests files
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Download tests artifacts
+        id: tests
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_commit.id }}
+          name: ${{ github.event.repository.name }}-tests
+          github-token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}
 
       - name: Run
         id: run
+        working-directory: ${{ runner.temp }}
+        env:
+          file: ${{ runner.temp }}/scripts/tests/z-wave-stack-binaries-test.sh
         # yamllint disable rule:line-length
         run: |
           set -x
@@ -92,7 +98,8 @@ jobs:
           export ZPC_COMMAND="docker-compose up --abort-on-container-exit"
           export z_wave_stack_binaries_bin_dir="${{ runner.temp }}/z-wave-stack-binaries/bin"
           export ZPC_ARGS="--log.level=d"
-          ./scripts/tests/z-wave-stack-binaries-test.sh
+          chmod u+rx ${{ env.file }}
+          ${{ env.file }}
         # yamllint enable rule:line-length
         continue-on-error: true
 


### PR DESCRIPTION
CodeQL complain about it, and GH suggests to use assets,

It is unclear to me how this can be exploited in fork on job without pull_request_target (that one could be exploited).

Anyway this workflow requieres permissions:
- Workflows (RW)

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


