### PR TITLE
fix(zwapi) Harden zwapi_connection_tx in zwapi_connection.c

### DIFF
--- a/applications/zpc/components/zwave_api/test/CMakeLists.txt
+++ b/applications/zpc/components/zwave_api/test/CMakeLists.txt
@@ -59,3 +59,13 @@ EXCLUDE zwapi_connection.c
         zwapi_session.c
         zwapi_init.c
 )
+
+target_add_unittest(zwave_api
+NAME zwapi_connection_test
+SOURCES zwapi_connection_test.c
+        zwapi_internal_init_mock.c
+DEPENDS zwapi_internal_mock
+        zwave_api_mock
+EXCLUDE zwapi_session.c 
+        zwapi_init.c
+)

--- a/applications/zpc/components/zwave_api/test/zwapi_connection_test.c
+++ b/applications/zpc/components/zwave_api/test/zwapi_connection_test.c
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * # License
+ * <b>Copyright 2025 Silicon Laboratories Inc. www.silabs.com</b>
+ ******************************************************************************
+ * The licensor of this software is Silicon Laboratories Inc. Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement. This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ *****************************************************************************/
+#include "unity.h"
+#include <stdio.h>
+
+#include <unity.h>
+#include "zwapi_connection.h"
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Woverflow"
+#endif
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif
+
+/// Setup the test suite (called once before all test_xxx functions are called)
+void suiteSetUp() {}
+
+/// Teardown the test suite (called once after all test_xxx functions are called)
+int suiteTearDown(int num_failures)
+{
+  return num_failures;
+}
+
+/// Called before each and every test
+void setUp() {}
+
+void test_zwapi_connection_tx_invalid_payload_full()
+{
+  uint8_t cmd  = 0x01;
+  uint8_t type = 0x02;
+  uint8_t buffer [0xFF] = {0}; ///< Maximum of len type
+  uint8_t len     = sizeof(buffer);
+  bool ack_needed = true;
+  
+  // Expect the function to detect overflow
+  zwapi_connection_tx(cmd, type, buffer, len, ack_needed);
+}
+
+void test_zwapi_connection_tx_valid_inputs()
+{
+  uint8_t cmd  = 0x01;
+  uint8_t type = 0x02;
+  uint8_t buffer[10]
+    = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xA0};
+  uint8_t len     = sizeof(buffer);
+  bool ack_needed = true;
+
+  // Expect the function to execute without errors
+  zwapi_connection_tx(cmd, type, buffer, len, ack_needed);
+}
+
+void test_zwapi_connection_tx_null_buffer()
+{
+  uint8_t cmd     = 0x01;
+  uint8_t type    = 0x02;
+  uint8_t *buffer = NULL;
+  uint8_t len     = 0;
+  bool ack_needed = true;
+
+  // Expect the function to not crash
+  zwapi_connection_tx(cmd, type, buffer, len, ack_needed);
+}


### PR DESCRIPTION
Change is obvious, it prevent an overflow,
note that functions did not test all inputs params specially when it is done in caller
(eg: in  zwave_api_send_data reject frames above limit).

Bug-SiliconLabs: UIC-3666
Bug-SLVDBBP: 3169925

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


