### PR TITLE
Fix extra quote in how_to_interact_with_clusters.rst

### DIFF
--- a/applications/zpc/how_to_interact_with_clusters.rst
+++ b/applications/zpc/how_to_interact_with_clusters.rst
@@ -133,7 +133,7 @@ information about this in the associated ``README.md`` in the
          </attribute>
          <attribute id="0005" name="MaxTone" type="uint8"/>
          <attribute id="0006" name="ToneDescription" type="string"/>
-         <attribute id="0007" name="ToneDuration" type="uint16""/>
+         <attribute id="0007" name="ToneDuration" type="uint16"/>
        </attributes>
        <commands>
        </commands>


### PR DESCRIPTION
## Change
Fixes an extra quote I found when following how_to_interact_with_clusters.rst

## Checklist
- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


