### PR TITLE
fix(s2): Harden S2_init_ctx using safe memset

### DIFF
--- a/applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/protocol/S2.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/protocol/S2.c
@@ -1279,7 +1279,7 @@ S2_init_ctx(uint32_t home)
     return 0;
   }
 #endif
-  memset(ctx, 0, sizeof(struct S2));
+  explicit_bzero(ctx, sizeof(struct S2));
 
   ctx->my_home_id = home;
   ctx->loaded_keys = 0;
@@ -1329,7 +1329,7 @@ void
 S2_destroy(struct S2* p_context)
 {
   CTX_DEF
-  memset(ctxt, 0, sizeof(struct S2));
+  explicit_bzero(ctxt, sizeof(struct S2));
 #ifndef SINGLE_CONTEXT
   free(ctxt);
 #endif


### PR DESCRIPTION
This is a simple change to check the static analysis.

SonarQube is reporting:

This "memset" is likely to be optimized away by the compiler; either remove it or replace it with "memset_s".

While memset_s is suggested it is not implemented widely (it is optional), at this stage i am following GNU standards until it stabilizes.

Relate-to: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1967.htm
Relate-to: https://en.cppreference.com/w/c/string/byte/memset
Relate-to: https://sourceware.org/glibc/manual/2.41/html_node/Erasing-Sensitive-Data.html
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/issues/100
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/42

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


