### PR TITLE
fix(s2): Support C23 for secure memset (for MacOS clang-17)

### DIFF
--- a/applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/protocol/S2.c
+++ b/applications/zpc/components/zwave/zwave_transports/s2/libs/zw-libs2/protocol/S2.c
@@ -1279,7 +1279,17 @@ S2_init_ctx(uint32_t home)
     return 0;
   }
 #endif
+
+  // Erase sensitive memory safely
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+  memset_explicit(ctx, 0, sizeof(struct S2));
+#elif defined(HAVE_EXPLICIT_BZERO) // for gcc-12
   explicit_bzero(ctx, sizeof(struct S2));
+#elif defined(__APPLE__) // for MacOS
+  memset_s(ctx, 0, sizeof(struct S2));
+#else
+  memset(ctx, 0, sizeof(struct S2)); //NOSONAR: Fallback option
+#endif
 
   ctx->my_home_id = home;
   ctx->loaded_keys = 0;


### PR DESCRIPTION
The previously introduced patch break MacOS support, this transition code to C23 make it usable on both OS (Linux, MacOS).

Note that current version of gcc-12 in debian stable is not supporting this C23 function, so it fallback to the safer option for memset in this release.

Origin: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/pull/92
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/85
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/137

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


